### PR TITLE
Keyboard setup no change

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -28,7 +28,7 @@ install_google_chrome: true
 
 # keyboard config
 configure_keyboard: true
-keyboard_model: pc105
+keyboard_model:
 keyboard_layout: us
 keyboard_variant: intl
 keyboard_options:

--- a/default.config.yml
+++ b/default.config.yml
@@ -28,10 +28,8 @@ install_google_chrome: true
 
 # keyboard config
 configure_keyboard: true
-keyboard_model:
 keyboard_layout: us
 keyboard_variant: intl
-keyboard_options:
 keyboard_c_cedilla: false
 
 # SSH config

--- a/main.yml
+++ b/main.yml
@@ -10,9 +10,6 @@
         - "{{ playbook_dir }}/config.yml"
 
   handlers:
-    - name: dpkg-reconfigure keyboard-configuration
-      become: true
-      command: /usr/sbin/dpkg-reconfigure -f noninteractive keyboard-configuration
     - name: restart gnome
       command: killall -SIGQUIT gnome-shell
     - name: delete openrgb repo
@@ -66,10 +63,6 @@
       import_tasks: tasks/keypass-xc.yml
       when: install_keypass_xc
 
-    - name: International keyboard
-      import_tasks: tasks/keyboard.yml
-      when: configure_keyboard
-
     - name: Create SSH key
       include_tasks: tasks/ssh.yml
       when: configure_ssh
@@ -105,6 +98,10 @@
     - name: Gnome Setup
       import_tasks: tasks/gnome-setup.yml
       when: gnome_setup
+
+    - name: Configure keyboard
+      import_tasks: tasks/keyboard.yml
+      when: configure_keyboard
 
     - name: Configure terminal
       include_tasks: tasks/terminal.yml

--- a/tasks/gnome-setup.yml
+++ b/tasks/gnome-setup.yml
@@ -11,7 +11,7 @@
     name: python3-psutil
   become: true
 - name: Setup night-light
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
     state: present
@@ -34,14 +34,14 @@
     - key: "/org/gnome/settings-daemon/plugins/color/night-light-schedule-from"
       value: 16.0
 - name: Setup favorite-apps
-  dconf:
+  community.general.dconf:
     key: /org/gnome/shell/favorite-apps
     value: "{{ gnome_favorite_apps }}"
 - name: Disable activities overview hot corner
-  dconf:
+  community.general.dconf:
     key: /org/gnome/desktop/interface/enable-hot-corners
     value: "false"
 - name: Disable lock-screen notifications
-  dconf:
+  community.general.dconf:
     key: /org/gnome/desktop/notifications/show-in-lock-screen
     value: "false"

--- a/tasks/keyboard.yml
+++ b/tasks/keyboard.yml
@@ -1,11 +1,9 @@
 ---
-- name: Change keyboard settings.
-  template:
-    src: keyboard/config.t2
-    dest: "/etc/default/keyboard"
-  notify:
-    - dpkg-reconfigure keyboard-configuration
-  become: true
+- name: Change keyboard settings
+  community.general.dconf:
+    key: /org/gnome/desktop/input-sources/sources
+    value: "[('xkb', '{{ keyboard_layout | string }}{% if keyboard_variant %}+{{ keyboard_variant | string }}{% endif %}')]"
+  when: keyboard_layout
 - name: Configure c-cedilla
   lineinfile:
     path: /etc/environment

--- a/templates/keyboard/config.t2
+++ b/templates/keyboard/config.t2
@@ -1,11 +1,9 @@
-# KEYBOARD CONFIGURATION FILE
-
-# Consult the keyboard(5) manual page.
-
-XKBMODEL="{{ keyboard_model }}"
-XKBLAYOUT="{{ keyboard_layout }}"
-XKBVARIANT="{{ keyboard_variant }}"
-
-XKBOPTIONS="{{ keyboard_options }}"
-
-BACKSPACE="guess"
+{% if keyboard_model %}XKBMODEL={{ keyboard_model }}
+{% endif %}
+{% if keyboard_layout %}XKBLAYOUT={{ keyboard_layout }}
+{% endif %}
+{% if keyboard_variant %}XKBVARIANT={{ keyboard_variant }}
+{% endif %}
+{% if keyboard_options %}XKBOPTIONS={{ keyboard_options }}
+{% endif %}
+BACKSPACE=guess

--- a/templates/keyboard/config.t2
+++ b/templates/keyboard/config.t2
@@ -1,9 +1,0 @@
-{% if keyboard_model %}XKBMODEL={{ keyboard_model }}
-{% endif %}
-{% if keyboard_layout %}XKBLAYOUT={{ keyboard_layout }}
-{% endif %}
-{% if keyboard_variant %}XKBVARIANT={{ keyboard_variant }}
-{% endif %}
-{% if keyboard_options %}XKBOPTIONS={{ keyboard_options }}
-{% endif %}
-BACKSPACE=guess


### PR DESCRIPTION
Gnome autogenerates /etc/default/keyboard, so no need for a template. It is all configured though /org/gnome/desktop/input-sources/sources